### PR TITLE
Fix successfull typos

### DIFF
--- a/Practice/Program.cs
+++ b/Practice/Program.cs
@@ -90,7 +90,7 @@ var stdActionSegment = new ActionSegment
     {
         SelectorType = SelectorType.ClassName,
         SelectorText = "alert",
-        Value = "successfull",
+        Value = "successful",
         InputType = InputType.Label
     }
 };
@@ -183,7 +183,7 @@ var submitAction = new ActionSegment
         SelectorType = SelectorType.ClassName,
         SelectorText = "alert",
         InputType = InputType.Label,
-        Value = "successfull"
+        Value = "successful"
     }
 };
 

--- a/Practice/Sample.cs
+++ b/Practice/Sample.cs
@@ -64,7 +64,7 @@ namespace Practice
 
             Print(100, "Checking is data saved or not!\n");
 
-            if (!ele.Text.Contains("successfull"))
+            if (!ele.Text.Contains("successful"))
                 throw new InvalidOperationException($"Failed to saved data. Return message - '{ele.Text}'");
 
             Print(400, "Data successfully saved.\n");
@@ -100,7 +100,7 @@ namespace Practice
 
             Print(100, "Checking is data saved or not!\n");
 
-            if (!ele.Text.Contains("successfull"))
+            if (!ele.Text.Contains("successful"))
                 throw new InvalidOperationException($"Failed to saved data. Return message - '{ele.Text}'");
 
             Print(400, "Data successfully saved.\n");
@@ -157,7 +157,7 @@ namespace Practice
 
             Print(100, "Checking is data saved or not!\n");
 
-            if (!ele.Text.Contains("successfull"))
+            if (!ele.Text.Contains("successful"))
                 throw new InvalidOperationException($"Failed to saved data. Return message - '{ele.Text}'");
 
             Print(400, "Data successfully saved.\n");


### PR DESCRIPTION
## Summary
- fix inconsistent success message checking

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539692b7108331a80d14176e3f1bd0