### PR TITLE
Add null argument checks and unit tests

### DIFF
--- a/Automov/Move.cs
+++ b/Automov/Move.cs
@@ -92,8 +92,11 @@ namespace Automov
 
         public IMove Next(string navigateURL, List<IValueSegment> valueSegments, IActionSegment actionSegment)
         {
-            if (valueSegments == null || actionSegment == null)
+            if (valueSegments == null)
                 throw new ArgumentNullException(nameof(valueSegments));
+
+            if (actionSegment == null)
+                throw new ArgumentNullException(nameof(actionSegment));
 
             _core.Navigate(navigateURL);
 

--- a/UnitTestDemo/MoveNullArgumentsTests.cs
+++ b/UnitTestDemo/MoveNullArgumentsTests.cs
@@ -1,0 +1,42 @@
+using Automov;
+using Automov.Interfaces;
+using Automov.Loggers;
+using OpenQA.Selenium;
+
+namespace UnitTestDemo
+{
+    public class MoveNullArgumentsTests
+    {
+        [Test]
+        public void Next_WithNullValueSegments_ThrowsArgumentNullException()
+        {
+            // Arrange
+            IWebDriver? driver = null;
+            ILogger logger = new ConsoleLogger();
+            IMove move = new Automov.Move(driver!, logger);
+            IActionSegment action = new ActionSegment();
+
+            // Act
+            var ex = Assert.Throws<ArgumentNullException>(() => move.Next("http://example.com", (List<IValueSegment>)null!, action));
+
+            // Assert
+            Assert.That(ex!.ParamName, Is.EqualTo("valueSegments"));
+        }
+
+        [Test]
+        public void Next_WithNullActionSegment_ThrowsArgumentNullException()
+        {
+            // Arrange
+            IWebDriver? driver = null;
+            ILogger logger = new ConsoleLogger();
+            IMove move = new Automov.Move(driver!, logger);
+            var values = new List<IValueSegment>();
+
+            // Act
+            var ex = Assert.Throws<ArgumentNullException>(() => move.Next("http://example.com", values, null!));
+
+            // Assert
+            Assert.That(ex!.ParamName, Is.EqualTo("actionSegment"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- throw separate `ArgumentNullException`s for `valueSegments` and `actionSegment`
- add tests verifying these exceptions

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685398ac9a188331afc848ab60df3fe8