### PR TITLE
Enhance NUnit tests with assertions and cleanup

### DIFF
--- a/UnitTestDemo/UnitTest1.cs
+++ b/UnitTestDemo/UnitTest1.cs
@@ -23,6 +23,12 @@ namespace UnitTestDemo
             _aviator = new Automov.Move(_driver, _logger, 300);
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            _driver.Quit();
+        }
+
         [Test]
         public void LoginPage_ValidLoginAttempt_ReturnsLoggedIn()
         {
@@ -54,6 +60,11 @@ namespace UnitTestDemo
 
             // Act
             _aviator.Next(_url, loginValueSegment, loginActionSegment);
+
+            // Assert
+            Assert.That(_driver.Url, Is.Not.EqualTo(_url), "User should be redirected after successful login.");
+            Assert.That(_driver.FindElements(By.ClassName("validation-summary-errors")).Count, Is.EqualTo(0),
+                "Validation errors were displayed on successful login.");
 
         }
 
@@ -95,6 +106,11 @@ namespace UnitTestDemo
 
             // Act
             _aviator.Next(_url, loginValueSegment, loginActionSegment);
+
+            // Assert
+            Assert.That(_driver.Url, Is.EqualTo(_url), "User should remain on the login page after invalid attempt.");
+            var error = _driver.FindElement(By.XPath("//li[contains(text(),'Invalid login attempt.')]"));
+            Assert.That(error.Text, Does.Contain("Invalid login"), "Invalid login message was not displayed.");
 
         }
     }


### PR DESCRIPTION
## Summary
- verify page state after calling `_aviator.Next` in the tests
- close the browser after each test via TearDown

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685398b44b68833185494ce914db18d8